### PR TITLE
Add a config patch context manager

### DIFF
--- a/flexigurator/config_patch.py
+++ b/flexigurator/config_patch.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, Generator, Iterator, Type
+from typing import Any, Iterator, Type
 
 from confz import ConfZ, ConfZDataSource, ConfZSource
 

--- a/flexigurator/config_patch.py
+++ b/flexigurator/config_patch.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+from typing import Any, Generator, Iterator, Type
+
+from confz import ConfZ, ConfZDataSource, ConfZSource
+
+
+@contextmanager
+def patch_config(
+    config_class: Type[ConfZ], data: dict[str, Any] | ConfZSource | list[ConfZSource]
+) -> Iterator[None]:
+    """Patch a config class with additional sources.
+
+    This context manager temporarily updates the given config class with the provided data sources.
+    This is useful for testing where a specific set of configuration values needs to be changed for
+    a single test instance. Importantly, the provided configuration does not need to be complete,
+    as long as the original configuration sources are.
+
+    Args:
+        config_class (Type[ConfZ]): The ConfZ config class
+        data (dict[str, Any] | ConfZSource | list[ConfZSource]): A source of configuration in the
+            form of a dictionary or one or more ConfZ sources
+
+    Yields:
+        None: This context manager does not yield
+
+    """
+    if isinstance(data, dict):
+        data = ConfZDataSource(data)
+
+    if not isinstance(data, list):
+        data = [data]
+
+    patched_sources = config_class.CONFIG_SOURCES
+
+    if patched_sources is None:
+        patched_sources = []
+    elif not isinstance(patched_sources, list):
+        patched_sources = [patched_sources]
+
+    patched_sources += data
+
+    with config_class.change_config_sources(patched_sources):
+        yield

--- a/poetry.lock
+++ b/poetry.lock
@@ -188,6 +188,23 @@ files = [
 ]
 
 [[package]]
+name = "confz"
+version = "1.8.1"
+description = "ConfZ is a configuration management library for Python based on pydantic."
+optional = false
+python-versions = ">=3.7.2,<4.0.0"
+files = [
+    {file = "confz-1.8.1-py3-none-any.whl", hash = "sha256:64c39218366902a7053c9f10baf368f34576e61121f465286c04d14327cde685"},
+    {file = "confz-1.8.1.tar.gz", hash = "sha256:61a8465930e91a2324dc505aedf4b5658e2a5516042df183ae2b15f3e90ab751"},
+]
+
+[package.dependencies]
+pydantic = ">=1.9.0,<2.0.0"
+python-dotenv = ">=0.19.2,<0.22.0"
+PyYAML = ">=5.4.1,<7.0.0"
+toml = ">=0.10.2,<0.11.0"
+
+[[package]]
 name = "coverage"
 version = "7.2.6"
 description = "Code coverage measurement for Python"
@@ -755,6 +772,20 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49"},
+    {file = "python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -891,6 +922,17 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.10"
 description = "Typing stubs for PyYAML"
@@ -947,4 +989,4 @@ requests = ">=2.0,<3.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "050b2dab102cb53d08038de2b6eba84f76cfbc4a2ea15ccb40dec5092fab4c6f"
+content-hash = "b0eab5182a7f8e754e8608d0a2f59ffb330197d29c6a5fc8e4abd2dfcf01618d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ jinja2 = "^3.1.2"
 mmh3 = "^4.0.0"
 pyyaml = "^6.0"
 invoke = "^2.1.2"
+confz = "^1.8.1"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexigurator"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python Configuration solution."
 authors = ["Thomas Bos <thymer.bos217@gmail.com>"]
 readme = "README.md"

--- a/tests/test_config_patcher.py
+++ b/tests/test_config_patcher.py
@@ -1,0 +1,152 @@
+from confz import ConfZ, ConfZDataSource
+from pydantic import BaseModel
+
+from flexigurator.config_patch import patch_config
+
+
+class TestSubModel(BaseModel):
+    __test__ = False
+    some_string: str
+
+
+class TestConfig1(ConfZ):  # type: ignore
+    __test__ = False
+    sub_model: TestSubModel
+    some_int: int
+    some_float: float
+
+
+class TestConfig2(ConfZ):  # type: ignore
+    __test__ = False
+    sub_model: TestSubModel
+    some_int: int
+    some_float: float
+
+    CONFIG_SOURCES = ConfZDataSource(dict(
+        sub_model=TestSubModel(some_string="old"),
+        some_int=1,
+        some_float=3.14
+    ))
+
+
+class TestConfig3(ConfZ):  # type: ignore
+    __test__ = False
+    sub_model: TestSubModel
+    some_int: int
+    some_float: float
+
+    CONFIG_SOURCES = [
+        ConfZDataSource(dict(
+            sub_model=TestSubModel(some_string="old"),
+        )),
+        ConfZDataSource(dict(
+            some_int=1,
+            some_float=3.14,
+        ))
+    ]
+
+
+def test_context():
+    data = dict(
+        some_int=2,
+    )
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().some_int == 2
+
+    assert TestConfig2().some_int == 1
+
+
+def test_config_without_sources():
+    data = dict(
+        sub_model=TestSubModel(some_string="new"),
+        some_int=2,
+        some_float=4.2
+    )
+    with patch_config(TestConfig1, data):
+        assert TestConfig1().sub_model == data["sub_model"]
+        assert TestConfig1().some_int == data["some_int"]
+        assert TestConfig1().some_float == data["some_float"]
+
+
+def test_config_with_sources():
+    data = dict(
+        sub_model=TestSubModel(some_string="new"),
+        some_int=2,
+        some_float=4.2
+    )
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().sub_model == data["sub_model"]
+        assert TestConfig2().some_int == data["some_int"]
+        assert TestConfig2().some_float == data["some_float"]
+
+
+def test_config_add_partial_data_1():
+    data = dict(
+        sub_model=TestSubModel(some_string="new"),
+        some_int=2,
+    )
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().sub_model == data["sub_model"]
+        assert TestConfig2().some_int == data["some_int"]
+        assert TestConfig2().some_float == 3.14
+
+
+def test_config_add_partial_data_2():
+    data = dict(
+        some_int=2,
+        some_float=4.2,
+    )
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().sub_model.some_string == "old"
+        assert TestConfig2().some_int == data["some_int"]
+        assert TestConfig2().some_float == data["some_float"]
+
+
+def test_config_add_partial_data_3():
+    data = dict(
+        some_float=4.2,
+    )
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().sub_model.some_string == "old"
+        assert TestConfig2().some_int == 1
+        assert TestConfig2().some_float == data["some_float"]
+
+
+def test_config_data_source():
+    data = ConfZDataSource(dict(
+        sub_model=TestSubModel(some_string="new"),
+        some_int=2,
+        some_float=4.2
+    ))
+    with patch_config(TestConfig2, data):
+        assert TestConfig2().sub_model == data.data["sub_model"]
+        assert TestConfig2().some_int == data.data["some_int"]
+        assert TestConfig2().some_float == data.data["some_float"]
+
+
+def test_config_multiple_config_sources_1():
+    data = ConfZDataSource(dict(
+        sub_model=TestSubModel(some_string="new"),
+        some_int=2,
+        some_float=4.2
+    ))
+    with patch_config(TestConfig3, data):
+        assert TestConfig3().sub_model == data.data["sub_model"]
+        assert TestConfig3().some_int == data.data["some_int"]
+        assert TestConfig3().some_float == data.data["some_float"]
+
+
+def test_config_multiple_config_sources_2():
+    data = [
+        ConfZDataSource(dict(
+            sub_model=TestSubModel(some_string="new"),
+            some_int=2,
+        )),
+        ConfZDataSource(dict(
+            some_float=4.2
+        ))
+    ]
+    with patch_config(TestConfig3, data):
+        assert TestConfig3().sub_model.some_string == "new"
+        assert TestConfig3().some_int == 2
+        assert TestConfig3().some_float == 4.2


### PR DESCRIPTION
Adds a context manager which temporarily replaces config values with the supplied ones. Useful for testing.

Example usage:
```python

class Config(Confz):
  a: int = 1
  b: int = 2
  c: int = 3

data = dict(a=2)

with patch_config(Config, data):
  print(Config().a)  # Prints `2`

print(Config().a)  # Prints `1`
```