### PR TITLE
Add ConfigVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ Config().some_int     # 42
 
 Importantly, the new data does not need to be complete.
 
+### `ConfigVersions`
+Allows for easy storing and on-demand loading of configuration versions.
+
+```python
+from pathlib import Path
+from confz import ConfZFileSource
+from flexigurator import ConfigVersions, DirectorySource
+
+class Config(ConfZ):  # type: ignore
+    a: int
+    b: int
+
+class Configs(ConfigVersions):
+    CONFIG_CLASS = Config
+    BASE = dict(a=1, b=2)  # Optional base version which is loaded before other versions
+    test = ConfZFileSource("configs/test.yaml")
+    folder = DirectorySource(Path("configs/versions"))
+
+with Configs().version("test"):
+    print(Config())  # Configuration from the ConfZFileSource is now loaded
+
+with Configs().version("folder.version_1"):
+    print(Config())  # Configuration from "configs/versions/version_1.yaml" is loaded
+```
+
 
 ### `placeholder`
 When having nested, optional `BaseModel`s in your `Config`,

--- a/flexigurator/__init__.py
+++ b/flexigurator/__init__.py
@@ -1,3 +1,4 @@
 from flexigurator.config_patch import patch_config
 from flexigurator.form.form import ConfigForm
 from flexigurator.placeholder import NotConfiguredError, placeholder
+from flexigurator.config_versions import ConfigVersions, DirectorySource

--- a/flexigurator/__init__.py
+++ b/flexigurator/__init__.py
@@ -1,4 +1,4 @@
 from flexigurator.config_patch import patch_config
+from flexigurator.config_versions import ConfigVersions, DirectorySource
 from flexigurator.form.form import ConfigForm
 from flexigurator.placeholder import NotConfiguredError, placeholder
-from flexigurator.config_versions import ConfigVersions, DirectorySource

--- a/flexigurator/config_versions.py
+++ b/flexigurator/config_versions.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from functools import reduce
 from pathlib import Path
-from typing import Any, Mapping, Type, TypeVar, get_args
+from typing import Any, Mapping, Type, TypeVar
 
 from confz import ConfZ, ConfZDataSource, ConfZFileSource, ConfZSource
 
@@ -29,13 +29,10 @@ def _flatten(a: T | list[T], b: T | list[T]) -> list[T]:
 
 
 def is_config_source(source: Any):
-    if source is None:
-        return False
-
     return (
         isinstance(source, ConfZSource)
-        or (isinstance(source, dict) and get_args(type(source))[0] == str)
-        or (isinstance(source, list) and get_args(type(source)) == (ConfZSource,))
+        or (isinstance(source, dict) and all(isinstance(key, str) for key in source))
+        or (isinstance(source, list) and all(isinstance(item, ConfZSource) for item in source))
     )
 
 
@@ -124,6 +121,12 @@ class ConfigVersions(_VersionCollection):
         Args:
             version_name (str): The name of the configuration version
             config_class (Type[ConfZ]): The configuration class to patch
+
+        Yields:
+            ...
+
+        Raises:
+            AttributeError: When no config class is given or the version does not exist
         """
         config_class = config_class or getattr(self, "CONFIG_CLASS", None)
 

--- a/flexigurator/config_versions.py
+++ b/flexigurator/config_versions.py
@@ -104,6 +104,13 @@ class DirectorySource(_VersionCollection):
 
 
 class ConfigVersions(_VersionCollection):
+    """Hold various versions of configurations that can be loaded in a context manager.
+
+    One should implement this class in a config versions class (e.g. `Configs`). Fields pointing to
+    `ConfZSource`s, `DirectorySource`s, or dictionaries can then be added to load configuration
+    versions. These versions can then be loaded using `Configs.version` as a context manager.
+    """
+
     _instance = None
 
     def __new__(cls):
@@ -119,7 +126,7 @@ class ConfigVersions(_VersionCollection):
         """Select a version from the collection and patch the supplied config class.
 
         Args:
-            version_name (str): The name of the configuration version
+            version_name (str): The name of the configuration version (i.e. the field name)
             config_class (Type[ConfZ]): The configuration class to patch
 
         Yields:

--- a/flexigurator/config_versions.py
+++ b/flexigurator/config_versions.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Type, TypeVar
 
 from confz import ConfZ, ConfZDataSource, ConfZFileSource, ConfZSource
 
-from flexigurator import patch_config
+from flexigurator.config_patch import patch_config
 
 ConfigSource = ConfZSource | list[ConfZSource]
 
@@ -109,6 +109,20 @@ class ConfigVersions(_VersionCollection):
     One should implement this class in a config versions class (e.g. `Configs`). Fields pointing to
     `ConfZSource`s, `DirectorySource`s, or dictionaries can then be added to load configuration
     versions. These versions can then be loaded using `Configs.version` as a context manager.
+
+    Example:
+        class Config(ConfZ):  # type: ignore
+            a: int
+            b: int
+
+        class Configs(ConfigVersions):
+            CONFIG_CLASS = Config
+            BASE = dict(a=1, b=2)  # Optional base version which is loaded before other versions
+            test = ConfZFileSource("configs/test.yaml")
+
+        with Configs().version("test"):
+            print(Config())  # Configuration from the ConfZFileSource is now loaded
+
     """
 
     _instance = None

--- a/flexigurator/config_versions.py
+++ b/flexigurator/config_versions.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Mapping, Type, get_args
+
+from confz import ConfZ, ConfZDataSource, ConfZFileSource, ConfZSource
+
+from flexigurator import patch_config
+
+ConfigSource = ConfZSource | list[ConfZSource]
+
+
+def is_config_source(source: Any):
+    if source is None:
+        return False
+
+    return (
+        isinstance(source, ConfZSource)
+        or (isinstance(source, dict) and get_args(type(source))[0] == str)
+        or (isinstance(source, list) and get_args(type(source)) == (ConfZSource,))
+    )
+
+
+class _VersionCollection(ABC):
+    """Hold a collection of configuration versions."""
+
+    @abstractmethod
+    def _load_sources(self) -> None:
+        """Lazily load the config version sources."""
+
+    def get(self, version_name: str) -> ConfigSource:
+        self._load_sources()
+
+        version_name_split = version_name.split(".", maxsplit=1)
+        source_name = version_name_split[0]
+
+        source = getattr(self, source_name, None)
+
+        if not source:
+            raise AttributeError(f"Version source does not exist: {source_name}")
+
+        if isinstance(source, _VersionCollection):
+            if len(version_name_split) != 2:
+                raise ValueError(f'"{source_name}" is a collection!')
+
+            return source.get(version_name_split[1])
+
+        if isinstance(source, dict):
+            return ConfZDataSource(source)
+
+        if not is_config_source(source):
+            raise AttributeError(f"Not a version source: {source_name}")
+
+        return source  # type: ignore
+
+
+class DirectorySource(_VersionCollection):
+    """Hold a collection of version sources located in a folder.
+
+    Args:
+        path (Path): Path to the folder containing the `.yaml` configuration files
+
+    """
+
+    _path: Path
+
+    def __init__(self, path: Path):
+        super().__init__()
+        self._path = path
+
+    def _load_sources(self) -> None:
+        self._set_versions(self._load_versions(self._path))
+
+    @staticmethod
+    def _load_versions(path: Path) -> Mapping[str, ConfZFileSource | DirectorySource]:
+        versions = dict[str, ConfZFileSource | DirectorySource]()
+        for sub_path in path.glob("*"):
+            if path.suffix == ".yaml":
+                name = sub_path.stem
+                versions[name] = ConfZFileSource(sub_path)
+            if sub_path.is_dir():
+                name = sub_path.name
+                versions[name] = DirectorySource(sub_path)
+        return versions
+
+    def _set_versions(self, configs: Mapping[str, ConfigSource | DirectorySource]) -> None:
+        for name, version_source in configs.items():
+            setattr(self, name, version_source)
+
+
+class ConfigVersions(_VersionCollection):
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        # Set the default configuration version
+        if (default := getattr(self, "default", None)) is not None and (
+            config_class := getattr(self, "CONFIG_CLASS", None)
+        ) is not None:
+            if not is_config_source(default):
+                raise AttributeError("Not a version source: default")
+            config_class.CONFIG_SOURCES = default
+
+    def _load_sources(self) -> None:
+        pass
+
+    @contextmanager
+    def version(self, version_name: str, config_class: Type[ConfZ] | None = None):
+        config_class = config_class or getattr(self, "CONFIG_CLASS", None)
+
+        if not config_class:
+            raise AttributeError('Need to supply "config_class" as parameter or in ConfigVersions!')
+
+        version_sources = self.get(version_name)
+
+        with patch_config(config_class, version_sources):
+            yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flexigurator"
-version = "0.3.3"
+version = "0.4.0"
 description = "Python Configuration solution."
 authors = ["Thomas Bos <thymer.bos217@gmail.com>"]
 readme = "README.md"

--- a/tests/test_config_versions.py
+++ b/tests/test_config_versions.py
@@ -2,7 +2,8 @@ import os
 import tempfile
 from pathlib import Path
 
-from confz import ConfZ
+import pytest
+from confz import ConfZ, ConfZDataSource
 from pydantic import BaseModel
 
 from flexigurator.config_versions import ConfigVersions, DirectorySource
@@ -33,6 +34,19 @@ def test_config_versions():
         assert TestOptionalConfig().sub_model.some_string == "string"
 
 
+def test_config_versions_folder():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        test = [
+            ConfZDataSource(dict(sub_model=dict(some_string="test"))),
+            ConfZDataSource(dict(sub_model=dict(some_string="test_1"))),
+            ConfZDataSource(dict(sub_model=dict(some_string="test_2"))),
+        ]
+
+    with Configs().version("test"):
+        assert TestOptionalConfig().sub_model.some_string == "test_2"
+
+
 def test_config_versions_multiple():
     class Configs(ConfigVersions):
         CONFIG_CLASS = TestOptionalConfig
@@ -46,6 +60,53 @@ def test_config_versions_multiple():
         assert TestOptionalConfig().sub_model.some_string == "also_string"
     with Configs().version("test3"):
         assert TestOptionalConfig().sub_model.some_string == "also_also_string"
+
+
+def test_config_versions_config_class_as_parameter():
+    class Configs(ConfigVersions):
+        test = dict(sub_model=dict(some_string="string"))
+
+    with Configs().version("test", TestOptionalConfig):
+        assert TestOptionalConfig().sub_model.some_string == "string"
+
+
+def test_config_versions_raise_when_no_config_class():
+    class Configs(ConfigVersions):
+        test = dict(sub_model=dict(some_string="string"))
+
+    with pytest.raises(AttributeError):
+        with Configs().version("test"):
+            ...
+
+
+def test_config_versions_raise_when_source_doesnt_exist():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        test = dict(sub_model=dict(some_string="string"))
+
+    with pytest.raises(AttributeError):
+        with Configs().version("no_test"):
+            ...
+
+
+def test_config_versions_raise_when_version_is_not_config_source():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        test_1 = 5
+        test_2 = "string"
+        test_3 = None
+
+    with pytest.raises(AttributeError):
+        with Configs().version("test_1"):
+            ...
+
+    with pytest.raises(AttributeError):
+        with Configs().version("test_2"):
+            ...
+
+    with pytest.raises(AttributeError):
+        with Configs().version("test_3"):
+            ...
 
 
 def test_config_versions_base():
@@ -62,6 +123,23 @@ def test_config_versions_base():
     with Configs().version("test"):
         assert MultiFieldConfig().a == 3
         assert MultiFieldConfig().b == 2
+
+
+def test_config_base_folder():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        BASE = [
+            ConfZDataSource(dict(sub_model=dict(some_string="test"))),
+            ConfZDataSource(dict(sub_model=dict(some_string="test_1"))),
+        ]
+        test = [
+            ConfZDataSource(dict(sub_model=dict(some_string="test_1"))),
+            ConfZDataSource(dict(sub_model=dict(some_string="test_2"))),
+        ]
+
+    with Configs().version("test"):
+        assert TestOptionalConfig().sub_model.some_string == "test_2"
+
 
 
 def test_config_versions_base_incomplete():
@@ -103,3 +181,30 @@ def test_directory_source():
         with DirectoryConfigs().version("folder.nested.config_c"):
             assert MultiFieldConfig().a == 4
             assert MultiFieldConfig().b == 8
+
+
+def test_directory_source_raise_when_getting_folder():
+    config_a = """a: 1\nb: 2"""
+    config_b = """a: 2\nb: 4"""
+    config_c = """a: 4\nb: 8"""
+
+    with tempfile.TemporaryDirectory(dir=".") as temp_dir:
+        with open(temp_dir + "/config_a.yaml", "w") as file:
+            file.write(config_a)
+        with open(temp_dir + "/config_b.yaml", "w") as file:
+            file.write(config_b)
+        os.mkdir(temp_dir + "/nested")
+        with open(temp_dir + "/nested/config_c.yaml", "w") as file:
+            file.write(config_c)
+
+        class DirectoryConfigs(ConfigVersions):
+            CONFIG_CLASS = MultiFieldConfig
+            folder = DirectorySource(Path(temp_dir))
+
+        with pytest.raises(ValueError):
+            with DirectoryConfigs().version("folder"):
+                ...
+
+        with pytest.raises(ValueError):
+            with DirectoryConfigs().version("folder.nested"):
+                ...

--- a/tests/test_config_versions.py
+++ b/tests/test_config_versions.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+from pathlib import Path
+
+from confz import ConfZ
+from pydantic import BaseModel
+
+from flexigurator.config_versions import ConfigVersions, DirectorySource
+
+
+class TestSubModel(BaseModel):
+    __test__ = False
+    some_string: str
+
+
+class TestOptionalConfig(ConfZ):  # type: ignore
+    __test__ = False
+    sub_model: TestSubModel | None
+
+
+class MultiFieldConfig(ConfZ):  # type: ignore
+    __test__ = False
+    a: int
+    b: int
+
+
+def test_config_versions():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        test = dict(sub_model=dict(some_string="string"))
+
+    with Configs().version("test"):
+        assert TestOptionalConfig().sub_model.some_string == "string"
+
+
+def test_config_versions_multiple():
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = TestOptionalConfig
+        test1 = dict(sub_model=dict(some_string="string"))
+        test2 = dict(sub_model=dict(some_string="also_string"))
+        test3 = dict(sub_model=dict(some_string="also_also_string"))
+
+    with Configs().version("test1"):
+        assert TestOptionalConfig().sub_model.some_string == "string"
+    with Configs().version("test2"):
+        assert TestOptionalConfig().sub_model.some_string == "also_string"
+    with Configs().version("test3"):
+        assert TestOptionalConfig().sub_model.some_string == "also_also_string"
+
+
+def test_config_versions_base():
+
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = MultiFieldConfig
+        BASE = dict(a=1, b=2)
+        test = dict(a=3)
+
+    with Configs().version("BASE"):
+        assert MultiFieldConfig().a == 1
+        assert MultiFieldConfig().b == 2
+
+    with Configs().version("test"):
+        assert MultiFieldConfig().a == 3
+        assert MultiFieldConfig().b == 2
+
+
+def test_config_versions_base_incomplete():
+
+    class Configs(ConfigVersions):
+        CONFIG_CLASS = MultiFieldConfig
+        BASE = dict(b=2)
+        test = dict(a=3)
+
+    with Configs().version("test"):
+        assert MultiFieldConfig().a == 3
+        assert MultiFieldConfig().b == 2
+
+
+def test_directory_source():
+    config_a = """a: 1\nb: 2"""
+    config_b = """a: 2\nb: 4"""
+    config_c = """a: 4\nb: 8"""
+
+    with tempfile.TemporaryDirectory(dir=".") as temp_dir:
+        with open(temp_dir + "/config_a.yaml", "w") as file:
+            file.write(config_a)
+        with open(temp_dir + "/config_b.yaml", "w") as file:
+            file.write(config_b)
+        os.mkdir(temp_dir + "/nested")
+        with open(temp_dir + "/nested/config_c.yaml", "w") as file:
+            file.write(config_c)
+
+        class DirectoryConfigs(ConfigVersions):
+            CONFIG_CLASS = MultiFieldConfig
+            folder = DirectorySource(Path(temp_dir))
+
+        with DirectoryConfigs().version("folder.config_a"):
+            assert MultiFieldConfig().a == 1
+            assert MultiFieldConfig().b == 2
+        with DirectoryConfigs().version("folder.config_b"):
+            assert MultiFieldConfig().a == 2
+            assert MultiFieldConfig().b == 4
+        with DirectoryConfigs().version("folder.nested.config_c"):
+            assert MultiFieldConfig().a == 4
+            assert MultiFieldConfig().b == 8

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -14,7 +14,6 @@ class TestModel(BaseModel):
     sub_model: TestSubModel = placeholder(TestSubModel)
 
 
-
 def test_placeholder_crash_on_request_parameter():
     with pytest.raises(NotConfiguredError):
         TestModel().sub_model.some_string


### PR DESCRIPTION
Added a new class which builds on top of `ConfZ` configuration. It allows for easy configuration storing and loading on-demand.

```python
from pathlib import Path
from confz import ConfZFileSource
from flexigurator import ConfigVersions, DirectorySource

class Config(ConfZ):  # type: ignore
    a: int
    b: int

class Configs(ConfigVersions):
    CONFIG_CLASS = Config
    BASE = dict(a=1, b=2)  # Optional base version which is loaded before other versions
    test = ConfZFileSource("configs/test.yaml")
    folder = DirectorySource(Path("configs/versions"))

with Configs().version("test"):
    print(Config())  # Configuration from the ConfZFileSource is now loaded

with Configs().version("folder.version_1"):
    print(Config())  # Configuration from "configs/versions/version_1.yaml" is loaded
```